### PR TITLE
Caddy oauth plugins

### DIFF
--- a/oauth/.gitignore
+++ b/oauth/.gitignore
@@ -1,0 +1,1 @@
+Caddyfile

--- a/oauth/Caddyfile.example
+++ b/oauth/Caddyfile.example
@@ -2,17 +2,35 @@
 
 browse
 
+log /tmp/access.log
+
 oauth {
+    # path is the path you want to protect
+    # you can specify multiple paths
 	path            /data/
+	path            /data2/
+
+    # itsyou.online client ID
     client_id       mylab
-    client_secret   XXXXXX
+
+    # itsyou.online client secret   
+    client_secret   fHfT3yBlZXlNRAbOSVw-PLZI2y9HgqcA0IVzXXXXXXXXXXXXXXX
+
+    # oauth auth url
+    # leave it blank for default value
+    # default value : https://itsyou.online/v1/oauth/authorize
     auth_url        https://itsyou.online/v1/oauth/authorize
+
+    # oauth2 access token URL
+    # leave it blank for default value
+    # default value : https://itsyou.online/v1/oauth/access_token
     token_url       https://itsyou.online/v1/oauth/access_token
-    callback_path   /_iyo_callback
-    login_path      /_iyo_login
-    scopes          user:memberof:mylab
+
+    # oauth2 redirect URL
     redirect_url    http://localhost:2015/_iyo_callback
+
+    # scopes allowed to access this protected paths
+    # leave it blank if you don't want to specify it
+    scopes          user:memberof:mylab
 }
 
-
-log stdout

--- a/oauth/Caddyfile.example
+++ b/oauth/Caddyfile.example
@@ -30,7 +30,13 @@ oauth {
     redirect_url    http://localhost:2015/_iyo_callback
 
     # scopes allowed to access this protected paths
-    # leave it blank if you don't want to specify it
+    # leave it blank if you want to ignore it
     scopes          user:memberof:mylab
+
+    # usernames allowed to access this protected paths
+    # leave it blank to allow all usernames
+    # - each username need to be separated with `,`
+    # - you can specify it in multiple lines
+    usernames       dodo,jon,ibk
 }
 

--- a/oauth/Caddyfile.example
+++ b/oauth/Caddyfile.example
@@ -11,6 +11,7 @@ oauth {
     callback_path   /_iyo_callback
     login_path      /_iyo_login
     scopes          user:memberof:mylab
+    redirect_url    http://localhost:2015/_iyo_callback
 }
 
 

--- a/oauth/Caddyfile.example
+++ b/oauth/Caddyfile.example
@@ -1,0 +1,17 @@
+0.0.0.0
+
+browse
+
+oauth {
+	path            /data/
+    client_id       mylab
+    client_secret   XXXXXX
+    auth_url        https://itsyou.online/v1/oauth/authorize
+    token_url       https://itsyou.online/v1/oauth/access_token
+    callback_path   /_iyo_callback
+    login_path      /_iyo_login
+    scopes          user:memberof:mylab
+}
+
+
+log stdout

--- a/oauth/README.md
+++ b/oauth/README.md
@@ -1,0 +1,17 @@
+# caddy oauth middleware
+
+## using it
+
+Install caddydev
+```
+go get github.com/caddyserver/caddydev
+```
+
+Create `Caddyfile` based on `Caddyfile.example` file
+
+run it
+```
+caddydev
+```
+
+It will serve this directory

--- a/oauth/README.md
+++ b/oauth/README.md
@@ -9,7 +9,7 @@ go get github.com/caddyserver/caddydev
 
 Create `Caddyfile` based on `Caddyfile.example` file
 
-run it
+Run it
 ```
 caddydev
 ```

--- a/oauth/README.md
+++ b/oauth/README.md
@@ -1,6 +1,6 @@
 # caddy oauth middleware
 
-## using it
+## using it in development
 
 Install caddydev
 ```
@@ -15,3 +15,12 @@ caddydev
 ```
 
 It will serve this directory
+
+## using it in production
+
+Add below import line in Caddy's [run.go](https://github.com/mholt/caddy/blob/master/caddy/caddymain/run.go)
+```
+_ "github.com/itsyouonline/caddy-integration/oauth"
+```
+
+Then build caddy as usual

--- a/oauth/README.md
+++ b/oauth/README.md
@@ -1,6 +1,59 @@
-# caddy oauth middleware
+# caddy oauth plugin
 
-## using it in development
+This plugin protects resource paths using itsyou.online oauth2.
+
+## Features
+
+Plugin features:
+
+- protects paths based on oauth2 `scope`
+- protects paths based on oauth2 username
+- use JWT to make it stateless and reduce API calls to Oauth2 server
+- log following infos to stdout : host, time, http verb, path, http method, username
+
+## Usage
+Add oauth block to Caddyfile
+
+example
+```
+oauth {
+    # path is the path you want to protect
+    # you can specify multiple paths
+	  path            /data/
+	  path            /data2/
+
+    # itsyou.online client ID
+    client_id       mylab
+
+    # itsyou.online client secret   
+    client_secret   fHfT3yBlZXlNRAbOSVw-PLZI2y9HgqcA0IVzXXXXXXXXXXXXXXX
+
+    # oauth auth url
+    # leave it blank for default value
+    # default value : https://itsyou.online/v1/oauth/authorize
+    auth_url        https://itsyou.online/v1/oauth/authorize
+
+    # oauth2 access token URL
+    # leave it blank for default value
+    # default value : https://itsyou.online/v1/oauth/access_token
+    token_url       https://itsyou.online/v1/oauth/access_token
+
+    # oauth2 redirect URL
+    redirect_url    http://localhost:2015/_iyo_callback
+
+    # scopes allowed to access this protected paths
+    # leave it blank if you want to ignore it
+    scopes          user:memberof:mylab
+
+    # usernames allowed to access this protected paths
+    # leave it blank to allow all usernames
+    # - each username need to be separated with `,`
+    # - you can specify it in multiple lines
+    usernames       dodo,jon,ibk
+}
+```
+
+## Build and Run in Development
 
 Install caddydev
 ```
@@ -16,7 +69,7 @@ caddydev
 
 It will serve this directory
 
-## using it in production
+## Build and Run in Production
 
 Add below import line in Caddy's [run.go](https://github.com/mholt/caddy/blob/master/caddy/caddymain/run.go)
 ```

--- a/oauth/config.json
+++ b/oauth/config.json
@@ -1,0 +1,3 @@
+{
+	"directive" : "oauth"
+}

--- a/oauth/cookies.go
+++ b/oauth/cookies.go
@@ -1,0 +1,26 @@
+package oauth
+
+import (
+	"net/http"
+)
+
+const (
+	cookieName = "caddyoauth"
+)
+
+func setOauthCookies(code string, w http.ResponseWriter, r *http.Request) {
+	cookie := http.Cookie{
+		Name:  cookieName,
+		Value: code,
+		Path:  "/",
+	}
+	http.SetCookie(w, &cookie)
+}
+
+func getOauthCookies(r *http.Request) string {
+	c, err := r.Cookie(cookieName)
+	if err != nil {
+		return ""
+	}
+	return c.Value
+}

--- a/oauth/cookies.go
+++ b/oauth/cookies.go
@@ -8,7 +8,11 @@ const (
 	cookieName = "caddyoauth"
 )
 
-func setOauthCookies(code string, w http.ResponseWriter, r *http.Request) {
+func delCookies(w http.ResponseWriter) {
+	setCookies("", w)
+}
+
+func setCookies(code string, w http.ResponseWriter) {
 	cookie := http.Cookie{
 		Name:  cookieName,
 		Value: code,
@@ -17,7 +21,7 @@ func setOauthCookies(code string, w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, &cookie)
 }
 
-func getOauthCookies(r *http.Request) string {
+func getCookies(r *http.Request) string {
 	c, err := r.Cookie(cookieName)
 	if err != nil {
 		return ""

--- a/oauth/cookies.go
+++ b/oauth/cookies.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"net/http"
+	"time"
 )
 
 const (
@@ -9,14 +10,15 @@ const (
 )
 
 func delCookies(w http.ResponseWriter) {
-	setCookies("", w)
+	setCookies("", 0, w)
 }
 
-func setCookies(code string, w http.ResponseWriter) {
+func setCookies(code string, expire int64, w http.ResponseWriter) {
 	cookie := http.Cookie{
-		Name:  cookieName,
-		Value: code,
-		Path:  "/",
+		Name:    cookieName,
+		Value:   code,
+		Path:    "/",
+		Expires: time.Now().Add(time.Second * time.Duration(expire)),
 	}
 	http.SetCookie(w, &cookie)
 }

--- a/oauth/handler.go
+++ b/oauth/handler.go
@@ -86,11 +86,14 @@ func (h handler) serveHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 		}
 
 		// verify jwt token
-		if err := h.verifyJWTToken(token); err != nil {
+		info, err := h.verifyJWTToken(token)
+		if err != nil {
 			delCookies(w)
 			h.writeError(w, 500, err.Error())
 			return 500, err
 		}
+
+		logRequest(w, r, info)
 	}
 	return h.Next.ServeHTTP(w, r)
 }

--- a/oauth/handler.go
+++ b/oauth/handler.go
@@ -27,6 +27,7 @@ type handler struct {
 	LoginPath    string
 	CallbackPath string
 	OauthConf    *oauth2.Config
+	Usernames    map[string]struct{} // allowed usernames, empty to allow all
 	Paths        []string
 	Next         httpserver.Handler
 	hc           http.Client

--- a/oauth/handler.go
+++ b/oauth/handler.go
@@ -17,6 +17,7 @@ var (
 type token struct {
 	AccessToken string `json:"access_token"`
 	Scope       string `json:"scope"`
+	ExpiresIn   int64  `json:"expires_in"`
 	Info        struct {
 		Username string `json:"username"`
 	} `json:"info"`
@@ -58,14 +59,14 @@ func (h handler) serveCallback(w http.ResponseWriter, r *http.Request) (int, err
 	}
 
 	// get JWT token from IYO server
-	jwtToken, err := h.getJWTToken(code)
+	expire, jwtToken, err := h.getJWTToken(code)
 	if err != nil {
 		h.writeError(w, 500, err.Error())
 		return 500, err
 	}
 
 	// save JWT token in cookies
-	setCookies(jwtToken, w)
+	setCookies(jwtToken, expire, w)
 
 	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 	return http.StatusTemporaryRedirect, nil

--- a/oauth/handler.go
+++ b/oauth/handler.go
@@ -34,8 +34,6 @@ type handler struct {
 
 func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 	switch {
-	case httpserver.Path(r.URL.Path).Matches(h.LoginPath):
-		return h.serveLogin(w, r)
 	case httpserver.Path(r.URL.Path).Matches(h.CallbackPath):
 		return h.serveCallback(w, r)
 	default:

--- a/oauth/jwt.go
+++ b/oauth/jwt.go
@@ -1,0 +1,107 @@
+package oauth
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+var JWTPublicKey *ecdsa.PublicKey
+
+const (
+	iyoPubKey = `-----BEGIN PUBLIC KEY-----
+MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAES5X8XrfKdx9gYayFITc89wad4usrk0n2
+7MjiGYvqalizeSWTHEpnd7oea9IQ8T5oJjMVH5cc0H5tFSKilFFeh//wngxIyny6
+6+Vq5t5B0V0Ehy01+2ceEon2Y0XDkIKv
+-----END PUBLIC KEY-----`
+)
+
+func init() {
+	var err error
+
+	JWTPublicKey, err = jwt.ParseECPublicKeyFromPEM([]byte(iyoPubKey))
+	if err != nil {
+		log.Fatalf("failed to parse pub key:%v", err)
+	}
+}
+
+func (h handler) verifyJWTToken(tokenStr string) error {
+	// verify token
+	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
+		if token.Method != jwt.SigningMethodES384 {
+			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+		}
+		return JWTPublicKey, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// get claims
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !(ok && token.Valid) {
+		return fmt.Errorf("invalid token")
+	}
+
+	// check scopes
+	if len(h.OauthConf.Scopes) == 0 {
+		return nil
+	}
+
+	var scopes []string
+	for _, v := range claims["scope"].([]interface{}) {
+		scopes = append(scopes, v.(string))
+	}
+
+	inScopes := func(scope string) bool {
+		for _, s := range scopes {
+			if s == scope {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, s := range h.OauthConf.Scopes {
+		if !inScopes(s) {
+			return fmt.Errorf("user doesn't have `%v` scope", s)
+		}
+	}
+	return nil
+}
+func (h handler) getJWTToken(code string) (string, error) {
+	// get oauth2 token
+	token, err := h.getToken(code)
+	if err != nil {
+		return "", err
+	}
+
+	// build request
+	req, err := http.NewRequest("GET", "https://itsyou.online/v1/oauth/jwt", nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Authorization", "token "+token.AccessToken)
+
+	if len(h.OauthConf.Scopes) > 0 {
+		q := req.URL.Query()
+		q.Add("scope", strings.Join(h.OauthConf.Scopes, ","))
+		req.URL.RawQuery = q.Encode()
+	}
+
+	// do request
+	resp, err := h.hc.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	return string(body), err
+}

--- a/oauth/jwt.go
+++ b/oauth/jwt.go
@@ -74,17 +74,18 @@ func (h handler) verifyJWTToken(tokenStr string) error {
 	}
 	return nil
 }
-func (h handler) getJWTToken(code string) (string, error) {
+
+func (h handler) getJWTToken(code string) (int64, string, error) {
 	// get oauth2 token
 	token, err := h.getToken(code)
 	if err != nil {
-		return "", err
+		return 0, "", err
 	}
 
 	// build request
 	req, err := http.NewRequest("GET", "https://itsyou.online/v1/oauth/jwt", nil)
 	if err != nil {
-		return "", err
+		return 0, "", err
 	}
 
 	req.Header.Set("Authorization", "token "+token.AccessToken)
@@ -98,10 +99,10 @@ func (h handler) getJWTToken(code string) (string, error) {
 	// do request
 	resp, err := h.hc.Do(req)
 	if err != nil {
-		return "", err
+		return 0, "", err
 	}
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
-	return string(body), err
+	return token.ExpiresIn, string(body), err
 }

--- a/oauth/log.go
+++ b/oauth/log.go
@@ -1,0 +1,21 @@
+package oauth
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+func logRequest(w http.ResponseWriter, r *http.Request, info *jwtInfo) {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+
+	timeStr := time.Now().Format("2/Jan/2006:15:04:05 -0700")
+
+	str := fmt.Sprintf(`%v [%v] "%v %v %v" %v`, host, timeStr, r.Method, r.URL.Path, r.Proto, info.Username)
+
+	fmt.Printf("%v\n", str)
+}

--- a/oauth/log.go
+++ b/oauth/log.go
@@ -8,6 +8,7 @@ import (
 )
 
 func logRequest(w http.ResponseWriter, r *http.Request, info *jwtInfo) {
+	// get client host without the port
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		host = r.RemoteAddr
@@ -17,5 +18,9 @@ func logRequest(w http.ResponseWriter, r *http.Request, info *jwtInfo) {
 
 	str := fmt.Sprintf(`%v [%v] "%v %v %v" %v`, host, timeStr, r.Method, r.URL.Path, r.Proto, info.Username)
 
+	// we don't use log package here because
+	// - it already used by caddy core
+	// - we always want it to log to stdout
+	// - caddy core might set the output to something else
 	fmt.Printf("%v\n", str)
 }

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -13,6 +13,7 @@ import (
 
 type config struct {
 	Paths        []string
+	RedirectURL  string
 	LoginPath    string
 	CallbackPath string
 	ClientID     string
@@ -93,6 +94,8 @@ func parse(c *caddy.Controller) (config, error) {
 						return conf, err
 					}
 					conf.Paths = append(conf.Paths, p)
+				case "redirect_url":
+					conf.RedirectURL, err = parseOne(c)
 				case "callback_path":
 					conf.CallbackPath, err = parseOne(c)
 				case "login_path":

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -1,0 +1,146 @@
+package oauth
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/mholt/caddy"
+	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"golang.org/x/oauth2"
+)
+
+type config struct {
+	Paths        []string
+	LoginPath    string
+	CallbackPath string
+	ClientID     string
+	ClientSecret string
+	AuthURL      string
+	TokenURL     string
+	Scopes       []string
+}
+
+func init() {
+	caddy.RegisterPlugin("oauth", caddy.Plugin{
+		ServerType: "http",
+		Action:     setup,
+	})
+}
+
+func setup(c *caddy.Controller) error {
+	conf, err := parse(c)
+	if err != nil {
+		return err
+	}
+
+	// Runs on Caddy startup, useful for services or other setups.
+	c.OnStartup(func() error {
+		fmt.Printf("caddy_oauth plugin is initiated with conf=%#v\n", conf)
+		return nil
+	})
+
+	// Runs on Caddy shutdown, useful for cleanups.
+	c.OnShutdown(func() error {
+		fmt.Println("caddy_oauth plugin is cleaning up")
+		return nil
+	})
+
+	oauthConfig := &oauth2.Config{
+		RedirectURL:  "http://localhost:2015/_iyo_callback",
+		ClientID:     conf.ClientID,
+		ClientSecret: conf.ClientSecret,
+		Scopes:       conf.Scopes,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  conf.AuthURL,
+			TokenURL: conf.TokenURL,
+		},
+	}
+
+	httpserver.GetConfig(c).AddMiddleware(func(next httpserver.Handler) httpserver.Handler {
+		return &handler{
+			OauthConf:    oauthConfig,
+			LoginPath:    conf.LoginPath,
+			CallbackPath: conf.CallbackPath,
+			Paths:        conf.Paths,
+			Next:         next,
+			hc:           http.Client{},
+		}
+	})
+	return nil
+}
+
+func parse(c *caddy.Controller) (config, error) {
+	// This parses the following config blocks
+	/*
+		oauth {
+			path /hello
+		}
+	*/
+	var err error
+	conf := config{}
+	for c.Next() {
+		args := c.RemainingArgs()
+		switch len(args) {
+		case 0:
+			// no argument passed, check the config block
+			for c.NextBlock() {
+				switch c.Val() {
+				case "path":
+					p, err := parseOne(c)
+					if err != nil {
+						return conf, err
+					}
+					conf.Paths = append(conf.Paths, p)
+				case "callback_path":
+					conf.CallbackPath, err = parseOne(c)
+				case "login_path":
+					conf.LoginPath, err = parseOne(c)
+				case "client_id":
+					conf.ClientID, err = parseOne(c)
+				case "client_secret":
+					conf.ClientSecret, err = parseOne(c)
+				case "auth_url":
+					conf.AuthURL, err = parseOne(c)
+				case "token_url":
+					conf.TokenURL, err = parseOne(c)
+				case "scopes":
+					var str string
+					str, err = parseOne(c)
+					if err != nil {
+						return conf, err
+					}
+					conf.Scopes = append(conf.Scopes, strings.Split(str, ",")...)
+				}
+				if err != nil {
+					return conf, err
+				}
+			}
+		default:
+			// we want only one argument max
+			return conf, c.ArgErr()
+		}
+	}
+	return conf, nil
+}
+
+// parse exactly one arguments
+func parseOne(c *caddy.Controller) (string, error) {
+	if !c.NextArg() {
+		// we are expecting a value
+		return "", c.ArgErr()
+	}
+	val := c.Val()
+	if c.NextArg() {
+		// we are expecting only one value.
+		return "", c.ArgErr()
+	}
+	return val, nil
+}
+
+func init() {
+	if os.Getenv("CADDY_DEV_MODE") == "1" {
+		httpserver.RegisterDevDirective("oauth", "browse")
+	}
+}

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -49,7 +49,7 @@ func setup(c *caddy.Controller) error {
 	})
 
 	oauthConfig := &oauth2.Config{
-		RedirectURL:  "http://localhost:2015/_iyo_callback",
+		RedirectURL:  conf.RedirectURL,
 		ClientID:     conf.ClientID,
 		ClientSecret: conf.ClientSecret,
 		Scopes:       conf.Scopes,


### PR DESCRIPTION
Implement #1 and #2 

Plugin features:

- protects paths based on oauth2 scope
- protects paths based on oauth2 username
- use JWT to make it stateless and reduce API calls to Oauth2 server
- log following infos to stdout : host, time, http verb, path, http method, username

More info can be found at https://github.com/itsyouonline/caddy-integration/blob/oauth/oauth/README.md