### PR TITLE
Update import path

### DIFF
--- a/oauth/handler.go
+++ b/oauth/handler.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"time"
 
-	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 	"golang.org/x/oauth2"
 )
 

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/mholt/caddy"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/caddyserver/caddy"
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 	"golang.org/x/oauth2"
 )
 


### PR DESCRIPTION
Update Caddy import paths (organization) from _mholt/caddy_ to _caddyserver/caddy_ due to the change in the organization according to the following:
https://github.com/coredns/coredns/issues/2959